### PR TITLE
fix(ci): ensure pipeline tests execute fully

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "migrate": "ts-node -r tsconfig-paths/register src/migrations/migrate.ts",
     "lint": "eslint src/**/*.ts",
     "typecheck": "tsc --noEmit",
-    "test": "jest"
+    "test": "jest --passWithNoTests"
   },
   "keywords": [
     "anlagen",

--- a/scripts/test-ci.sh
+++ b/scripts/test-ci.sh
@@ -26,10 +26,10 @@ run_test() {
     
     if eval $test_command; then
         echo -e "${GREEN}✓ ${test_name} passed${NC}"
-        ((TESTS_PASSED++))
+        ((TESTS_PASSED+=1))
     else
         echo -e "${RED}✗ ${test_name} failed${NC}"
-        ((TESTS_FAILED++))
+        ((TESTS_FAILED+=1))
         # Don't exit on failure, continue with other tests
     fi
 }


### PR DESCRIPTION
## Summary
- run Jest with `--passWithNoTests` so empty test suites no longer fail
- fix CI pipeline script counters so `set -e` doesn't stop execution

## Testing
- `npm test`
- `bash scripts/test-ci.sh`


------
https://chatgpt.com/codex/tasks/task_e_689af99b275483298a66870c446df39f