### PR TITLE
Fix Jest ESM locale import and enhance App tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,9 @@
       "react-app/jest"
     ]
   },
+  "jest": {
+    "transformIgnorePatterns": ["node_modules/(?!(date-fns)/)"]
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,46 +1,39 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import App from './App';
 
-// Mock react-router-dom
-jest.mock('react-router-dom', () => ({
-  BrowserRouter: ({ children }: any) => <div>{children}</div>,
-  Routes: ({ children }: any) => <div>{children}</div>,
-  Route: () => <div>Route</div>,
-  Navigate: () => <div>Navigate</div>,
-  useAuth: () => ({ user: null, loading: false }),
-}));
-
-// Mock react-query
-jest.mock('react-query', () => ({
-  QueryClient: class MockQueryClient {
-    // Empty class for testing
-  },
-  QueryClientProvider: ({ children }: any) => <div>{children}</div>,
-}));
-
-// Mock react-hot-toast
-jest.mock('react-hot-toast', () => ({
-  Toaster: () => <div>Toaster</div>,
-}));
-
-// Mock AuthContext
+// Mock AuthContext to avoid real authentication logic and network calls
 jest.mock('./contexts/AuthContext', () => ({
   AuthProvider: ({ children }: any) => <div>{children}</div>,
   useAuth: () => ({ user: null, loading: false }),
 }));
 
+const renderApp = () => {
+  const queryClient = new QueryClient();
+  render(
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
+  );
+};
+
 describe('App Component', () => {
   test('renders without crashing', () => {
-    render(<App />);
-    // When no user is authenticated, the app should show the login form
-    expect(screen.getByText('Anlagen-Management-System')).toBeInTheDocument();
+    renderApp();
+    // When no user is authenticated, the app should show the login heading
+    expect(
+      screen.getByRole('heading', { name: 'Anlagen-Management-System' })
+    ).toBeInTheDocument();
   });
-  
+
   test('renders login form when user is not authenticated', () => {
-    render(<App />);
-    expect(screen.getByPlaceholderText('E-Mail-Adresse')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Passwort')).toBeInTheDocument();
+    renderApp();
+    expect(screen.getByLabelText('E-Mail-Adresse')).toBeInTheDocument();
+    expect(screen.getByLabelText('Passwort')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Anmelden' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ImportReports.tsx
+++ b/frontend/src/pages/ImportReports.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { format } from 'date-fns';
-import { de } from 'date-fns/locale/de';
+// Import the German locale from the CommonJS entry point so Jest can transpile it
+import { de } from 'date-fns/locale';
 import {
   ArrowDownTrayIcon,
   ExclamationTriangleIcon,


### PR DESCRIPTION
## Summary
- Import date-fns German locale via CommonJS entry
- Configure Jest to transform date-fns package
- Rewrite App tests to use real Router and QueryClient with more robust queries

## Testing
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_689afe5ddb6c83299d101ffb309811ce