### PR TITLE
Remove date-fns dependency to fix frontend tests

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,6 @@
         "axios": "^1.3.4",
         "classnames": "^2.3.2",
         "clsx": "^2.1.1",
-        "date-fns": "^4.1.0",
         "file-saver": "^2.0.5",
         "framer-motion": "^12.23.9",
         "html5-qrcode": "^2.3.8",
@@ -7776,16 +7775,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,6 @@
     "axios": "^1.3.4",
     "classnames": "^2.3.2",
     "clsx": "^2.1.1",
-    "date-fns": "^4.1.0",
     "file-saver": "^2.0.5",
     "framer-motion": "^12.23.9",
     "html5-qrcode": "^2.3.8",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import App from './App';
-
-// Mock react-router-dom
-jest.mock('react-router-dom', () => ({
-  BrowserRouter: ({ children }: any) => <div>{children}</div>,
-  Routes: ({ children }: any) => <div>{children}</div>,
-  Route: () => <div>Route</div>,
-  Navigate: () => <div>Navigate</div>,
-  useAuth: () => ({ user: null, loading: false }),
-}));
 
 // Mock react-query
 jest.mock('react-query', () => ({
@@ -32,15 +24,25 @@ jest.mock('./contexts/AuthContext', () => ({
 
 describe('App Component', () => {
   test('renders without crashing', () => {
-    render(<App />);
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
     // When no user is authenticated, the app should show the login form
-    expect(screen.getByText('Anlagen-Management-System')).toBeInTheDocument();
+    expect(
+      screen.getAllByText('Anlagen-Management-System')[0]
+    ).toBeInTheDocument();
   });
-  
+
   test('renders login form when user is not authenticated', () => {
-    render(<App />);
-    expect(screen.getByPlaceholderText('E-Mail-Adresse')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Passwort')).toBeInTheDocument();
+    render(
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    );
+    expect(screen.getByLabelText('E-Mail-Adresse')).toBeInTheDocument();
+    expect(screen.getByLabelText('Passwort')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Anmelden' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/ImportReports.tsx
+++ b/frontend/src/pages/ImportReports.tsx
@@ -1,7 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { format } from 'date-fns';
-import { de } from 'date-fns/locale/de';
 import {
   ArrowDownTrayIcon,
   ExclamationTriangleIcon,
@@ -41,6 +39,16 @@ interface ImportError {
   error: string;
   details?: any;
 }
+
+const formatDate = (dateString: string) =>
+  new Intl.DateTimeFormat('de-DE', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date(dateString));
 
 const ImportReports: React.FC = () => {
   const navigate = useNavigate();
@@ -201,7 +209,7 @@ const ImportReports: React.FC = () => {
                             {importJob.filename}
                           </div>
                           <div className="text-sm text-gray-500">
-                            {format(new Date(importJob.created_at), 'dd.MM.yyyy HH:mm', { locale: de })}
+                            {formatDate(importJob.created_at)}
                             {importJob.created_by_name && ` • ${importJob.created_by_name}`}
                           </div>
                         </div>


### PR DESCRIPTION
## Summary
- Replace date-fns usage in ImportReports with Intl-based formatter
- Update App tests to render with MemoryRouter and use label queries
- Drop unused date-fns dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b02987b688329b1f33950e13381fe